### PR TITLE
Migrate extension to Manifest V3

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -6,11 +6,11 @@ jQuery.expr[':'].contains = function(a, i, m) {
 var jobSearcher = new function () {
     var totalItems = "<p>Total Items: #</p>";
 
-    var createSearchBox = function () {        
+    var createSearchBox = function () {
         $('#search-box').closest('div').remove();
         $('.js-jobs-list').prepend('<div class="search-box-div">' +
                                        '<input type="text" id="search-box" placeholder="Filter by Job Name..."></input>' +
-                                       '<img class="loader-img" src ='+ chrome.extension.getURL("assets/img/loader.gif") +' />'+
+                                       '<img class="loader-img" src ='+ chrome.runtime.getURL("assets/img/loader.gif") +' />'+
                                        '<p id="total-items"></p>'+
                                    '</div>');
     }
@@ -18,23 +18,23 @@ var jobSearcher = new function () {
         createSearchBox();
     }
     this.BindEvents = function(){
-        $('#search-box').bind('change', function(e){   
+        $('#search-box').bind('change', function(e){
             if(this.value.length == 0)
                 window.location.reload();
             else
-                FilterJobs(this.value);            
+                FilterJobs(this.value);
         });
     }
-    function FilterJobs(keyword){      
-        $('.loader-img').css('visibility', 'unset');        
+    function FilterJobs(keyword){
+        $('.loader-img').css('visibility', 'unset');
         $(".table-responsive table").load(window.location.href.split('?')[0] + "?from=0&count=1000000 .table-responsive table",
-        function() {            
-            var table = $('.table-responsive').find('table');            
+        function() {
+            var table = $('.table-responsive').find('table');
             var filtered = [],filteredCount;
             if($(".navbar-nav li.active a").attr("href").indexOf("recurring")!==-1) {
                 filtered = $(table).find('td:contains('+keyword+')').closest('tr');
             }
-            else 
+            else
             {
                 if($("div[class=list-group] .active").attr("href").indexOf("failed")!==-1)
                 {
@@ -54,7 +54,7 @@ var jobSearcher = new function () {
             $(table).find('tbody').append(filtered);
             $('.loader-img, .btn-toolbar').css('visibility', 'hidden');
             $('#total-items').text("Total Items: " + (filteredCount?filteredCount:filtered.length));
-        });  
+        });
     }
 }
 jobSearcher.Init();

--- a/assets/js/service-worker.js
+++ b/assets/js/service-worker.js
@@ -1,0 +1,16 @@
+// Service worker for Hangfire Job Filter extension
+// This is a minimal service worker required for Manifest V3
+// Content scripts are now declared in the manifest.json
+
+// Log when the service worker is installed
+chrome.runtime.onInstalled.addListener(() => {
+  console.log('Hangfire Job Filter extension installed');
+});
+
+// Keep the service worker alive when needed
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.action === 'keepAlive') {
+    sendResponse({ status: 'alive' });
+  }
+  return true;
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,24 +1,34 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Hangfire Job Filter",
   "short_name": "Hangfire Job Filter",
   "description": "Hangfire Dashboard Job Filter Extension",
-  "version": "1.1",
+  "version": "1.2",
   "permissions": [
+    "activeTab"
+  ],
+  "host_permissions": [
     "http://*/*jobs*",
     "https://*/*jobs*"
   ],
   "background": {
-    "scripts": [
-      "assets/js/background.js"
-    ],
-    "persistent": true
+    "service_worker": "assets/js/service-worker.js"
   },
-  "homepage_url": "http://github.com/suadev",
-  "browser_action": {
-    "default_title": "Hangfire Job Filter"    
+  "content_scripts": [
+    {
+      "matches": ["http://*/*jobs*", "https://*/*jobs*"],
+      "css": ["assets/css/styles.css"],
+      "js": ["assets/js/jquery.min.js", "assets/js/search.js"]
+    }
+  ],
+  "homepage_url": "https://github.com/suadev",
+  "action": {
+    "default_title": "Hangfire Job Filter"
   },
   "web_accessible_resources": [
-    "assets/img/*.gif"    
+    {
+      "resources": ["assets/img/*.gif"],
+      "matches": ["<all_urls>"]
+    }
   ]
 }


### PR DESCRIPTION
## Description
This PR updates the Hangfire Job Filter extension from Manifest V2 to Manifest V3 to comply with Google's current Chrome Web Store requirements. Manifest V2 is being phased out starting June 2024, and extensions need to be updated to remain compatible.

## Changes Made
- Updated manifest version from 2 to 3
- Replaced background script with a service worker
- Updated host permissions structure to use the dedicated `host_permissions` field
- Changed `browser_action` to `action` as required by Manifest V3
- Updated web accessible resources format to include matches property
- Added content scripts declaration in the manifest
- Replaced deprecated `chrome.extension.getURL` with `chrome.runtime.getURL`
- Incremented version number to 1.2

## Testing
The extension has been tested locally and continues to function as expected on Hangfire dashboard pages. The search functionality works correctly with the updated manifest and service worker implementation.

## Additional Notes
These changes are necessary to ensure the extension remains available in the Chrome Web Store as Google phases out support for Manifest V2 extensions.